### PR TITLE
chore: pass timezone with TZ envvar instead of host-path volume

### DIFF
--- a/.kontinuous/env/preprod/templates/notification.cronjob.yaml
+++ b/.kontinuous/env/preprod/templates/notification.cronjob.yaml
@@ -33,6 +33,8 @@ spec:
                   value: preproduction
                 - name: DATABASE_URL
                   value: "$(DATABASE_URL)"
+                - name: TZ
+                  value: Europe/Paris
               envFrom:
                 - configMapRef:
                     name: app-configmap
@@ -42,10 +44,3 @@ spec:
                     name: app-sealed-secret
                 - secretRef:
                     name: carte-jeune-engage-dev-app-access-key
-              volumeMounts:
-                - name: tz-paris
-                  mountPath: /etc/localtime
-          volumes:
-            - name: tz-paris
-              hostPath:
-                path: /usr/share/zoneinfo/Europe/Paris

--- a/.kontinuous/env/prod/templates/notification.cronjob.yaml
+++ b/.kontinuous/env/prod/templates/notification.cronjob.yaml
@@ -33,6 +33,8 @@ spec:
                   value: production
                 - name: DATABASE_URL
                   value: "$(DATABASE_URL)"
+                - name: TZ
+                  value: Europe/Paris
               envFrom:
                 - configMapRef:
                     name: app-configmap
@@ -42,10 +44,3 @@ spec:
                     name: app-sealed-secret
                 - secretRef:
                     name: carte-jeune-engage-prod-app-access-key
-              volumeMounts:
-                - name: tz-paris
-                  mountPath: /etc/localtime
-          volumes:
-            - name: tz-paris
-              hostPath:
-                path: /usr/share/zoneinfo/Europe/Paris


### PR DESCRIPTION
Une policy présente sur les cluster nous remonte une utilisation des host-paths, ce qui n'est pas recommandé.
Cette PR change la façon de passer les informations de TimeZone au pods des cronjobs pour pouvoir retirer le volume hostpath